### PR TITLE
add `is_latexify_enabled()` in `plotting.py`

### DIFF
--- a/probml_utils/__init__.py
+++ b/probml_utils/__init__.py
@@ -1,5 +1,5 @@
 from ._version import version as __version__
-from .plotting import savefig, latexify, _get_fig_name
+from .plotting import savefig, latexify, _get_fig_name, is_latexify_enabled
 from .pyprobml_utils import (
     hinton_diagram,
     plot_ellipse,

--- a/probml_utils/plotting.py
+++ b/probml_utils/plotting.py
@@ -66,6 +66,11 @@ def _get_fig_name(fname_full):
         fname = fname_full
     return fname + extention
 
+def is_latexify_enabled():
+    '''
+    returns true if LATEXIFY environment variable is set
+    '''
+    return "LATEXIFY" in os.environ
 
 def savefig(f_name, tight_layout=True, tight_bbox=False, *args, **kwargs):
     if len(f_name) == 0:

--- a/tests/test_latexify_status.py
+++ b/tests/test_latexify_status.py
@@ -1,0 +1,11 @@
+import probml_utils as pml
+import os
+
+def test_latexify_disabled():
+    if "LATEXIFY" in os.environ:
+        os.environ.pop("LATEXIFY")
+    assert(pml.is_latexify_enabled() == False)
+
+def test_latexify_enabled():
+    os.environ["LATEXIFY"] = ""     
+    assert(pml.is_latexify_enabled() == True)


### PR DESCRIPTION
## Decryption

Added `is_latexify_enabled()` to check if LATEXIFY environment variable is enabled. Because In many scenarios we may need to check LATEXIFY status in notebooks to vary the parameters of matplotlib accordingly.

- [x] Added `is_latexify_enabled()` in `plotting.py`
- [x] Added two tests in `tests/test_latexify_status.py`

## Issue
probml/pyprobml#771
