### PR TITLE
multiprocessing is removed from `check_dead_urls()`

### DIFF
--- a/probml_utils/url_utils.py
+++ b/probml_utils/url_utils.py
@@ -1,6 +1,5 @@
 import jax
 import requests
-import multiprocessing as mp
 from typing import Any
 
 def is_dead_url(link):
@@ -12,12 +11,21 @@ def is_dead_url(link):
         return 1
     return 0
 
-def check_dead_urls(urls: Any):
+def check_dead_urls(urls: Any, print_dead_url=False):
     '''
     returns if urls are dead or not
-    this method is using multiprocessing
     '''
-    pool = mp.Pool(30)
+    cnt=0
     mapping_values, mapping_treedef = jax.tree_flatten(urls) #pick only values (leaf noded)
-    status = pool.map(is_dead_url,mapping_values)
+    status = []
+    for url in mapping_values:
+        if is_dead_url(url):
+            if print_dead_url:
+                print(url)
+            status.append(1)
+            cnt+=1
+        else:
+            status.append(0)
+    if print_dead_url:
+        print(f"{cnt} dead urls detected!")
     return mapping_treedef.unflatten(status) # convert to original structure


### PR DESCRIPTION
Due to multi-processing in `check_dead_urls()`, it was giving unexpected output, hence it is removed.