### PR TITLE
chore: unpin distrax to fix install on Python 3.12+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 scikit-learn
 scipy
 graphviz
-distrax==0.1.3
+distrax>=0.1.3
 umap-learn
 pandas
 TexSoup


### PR DESCRIPTION
distrax==0.1.3 requires numpy<1.23, which cannot be built on Python 3.12+. Relaxing the pin to >=0.1.3 allows distrax 0.1.7 (which supports modern numpy) to be installed.